### PR TITLE
Use "deno fmt --check" instead of "git diff --exit-code"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,7 @@ jobs:
           deno-version: v1.x
       - name: Format
         run: |
-          deno fmt
-          git diff --exit-code
+          deno fmt --check
 
   # test:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the CI process to use `deno fmt --check` instead of `git diff --exit-code`.