### PR TITLE
Make denops singleton and optimize APIs

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1,0 +1,34 @@
+/**
+ * Context object which is exposed in l: namespace
+ */
+export interface Context {
+  [key: string]: unknown;
+}
+
+/**
+ * API of denops core
+ */
+export interface Api {
+  /**
+   * Call {func} with given {args} and return the result
+   */
+  call(func: string, ...args: unknown[]): Promise<unknown>;
+
+  /**
+   * Execute {cmd} under the {context}
+   */
+  cmd(cmd: string, context: Context): Promise<void>;
+
+  /**
+   * Evaluate {expr} under the {context} and return result
+   */
+  eval(expr: string, context: Context): Promise<unknown>;
+}
+
+/**
+ * Return if a given value is Context object or not
+ */
+export function isContext(value: unknown): value is Context {
+  const t = typeof value;
+  return t === "function" || (t === "object" && value !== null);
+}

--- a/cache.ts
+++ b/cache.ts
@@ -1,0 +1,29 @@
+// deno-lint-ignore no-explicit-any
+const that = globalThis as any;
+
+// Thread-local cache
+that.denopsCache = {};
+
+/**
+ * Get a value from the thread-local context
+ */
+export function getCache<T = unknown>(name: string): T | undefined {
+  return that.denopsCache[name];
+}
+
+/**
+ * Set a value to the thread-local cache
+ */
+export function setCache<T>(name: string, value: T): void {
+  that.denopsCache[name] = value;
+}
+
+/**
+ * Get a value from the thread-local cache or set if no value exist
+ */
+export function getCacheOrElse<T>(name: string, factory: () => T): T {
+  if (!that.denopsCache[name]) {
+    that.denopsCache[name] = factory();
+  }
+  return that.denopsCache[name];
+}

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
 export { Queue } from "https://deno.land/x/async@v1.0/mod.ts";
-export { Session } from "https://deno.land/x/msgpack_rpc@v2.4/mod.ts";
-export type { Dispatcher } from "https://deno.land/x/msgpack_rpc@v2.4/mod.ts";
+export { Session } from "https://deno.land/x/msgpack_rpc@v2.6/mod.ts";
+export type { Dispatcher } from "https://deno.land/x/msgpack_rpc@v2.6/mod.ts";
 export { copy as copyBytes } from "https://deno.land/std@0.87.0/bytes/mod.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,4 @@
+export * from "./api.ts";
+export * from "./cache.ts";
 export * from "./denops.ts";
 export * from "./worker.ts";


### PR DESCRIPTION
## API changes

Now `Denops` instance (`denops`) APIs changed as below.

| Previous                            | New                                         |
| ----------------------------------- | ------------------------------------------- |
| `call(fn: string, args: unknown[])` | `call(func: string, ...args: unknown[])`    |
| `command(expr: string)`             | `cmd(cmd: string, context: Context = {})`   |
| `eval(expr: string)`                | `eval(expr: string, context: Context = {})` |
| `echo(msg: string)`                 | REMOVED                                     |
| `echomsg(msg: string)`              | REMOVED                                     |

## Singleton

Module developers now can access singleton denops instance by `Denops.get()`.

## Context

The `cmd` and `eval` APIs now have `context` attribute which is exposed to the `l:` namespace so that users can transfer TypeScript variables to Vim script like:

```
await denops.cmd("echo variable", { variable: "This is TypeScript value" });

console.log(await denops.eval("variable", { variable: "This is TypeScript value" }));
```
