### PR TITLE
Add `dispatch` to dispatch other plugin's API

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -10,17 +10,22 @@ export interface Context {
  */
 export interface Api {
   /**
-   * Call {func} with given {args} and return the result
+   * Dispatch {method} of {name} plugin with given {params} directly and return the result
+   */
+  dispatch(name: string, method: string, params: unknown[]): Promise<unknown>;
+
+  /**
+   * Call {func} of Vim/Nevoim with given {args} and return the result
    */
   call(func: string, ...args: unknown[]): Promise<unknown>;
 
   /**
-   * Execute {cmd} under the {context}
+   * Execute {cmd} of Vim/Neovim under the {context}
    */
   cmd(cmd: string, context: Context): Promise<void>;
 
   /**
-   * Evaluate {expr} under the {context} and return result
+   * Evaluate {expr} of Vim/Neovim under the {context} and return result
    */
   eval(expr: string, context: Context): Promise<unknown>;
 }

--- a/denops.ts
+++ b/denops.ts
@@ -62,16 +62,24 @@ export class Denops implements Api {
     return this.#name;
   }
 
+  async dispatch(
+    name: string,
+    method: string,
+    params: unknown[],
+  ): Promise<unknown> {
+    return await this.#session.call("dispatch", name, method, params);
+  }
+
+  async call(func: string, ...args: unknown[]): Promise<unknown> {
+    return await this.#session.call("call", func, ...args);
+  }
+
   async cmd(cmd: string, context: Context = {}): Promise<void> {
     await this.#session.call("cmd", cmd, context);
   }
 
   async eval(expr: string, context: Context = {}): Promise<unknown> {
     return await this.#session.call("eval", expr, context);
-  }
-
-  async call(func: string, ...args: unknown[]): Promise<unknown> {
-    return await this.#session.call("call", func, ...args);
   }
 
   /**


### PR DESCRIPTION
To solve https://github.com/vim-denops/denops.vim/issues/7, add `dispatch` to `API` interface.